### PR TITLE
fix : 게시글 수정 시 기존 이미지 전체가 바뀌도록 수정, 게시글 수정 시 학교 정보도 수정할 수 있도록 변경

### DIFF
--- a/src/main/java/com/efub/bageasy/domain/post/controller/PostController.java
+++ b/src/main/java/com/efub/bageasy/domain/post/controller/PostController.java
@@ -61,8 +61,9 @@ public class PostController {
                                          @PathVariable Long postId,
                                          @RequestPart(value="dto") PostUpdateRequestDto requestDto,
                                          @RequestPart(value="addImage") List<MultipartFile> addImages) throws IOException {
+
         //이미지 삭제
-        List<Image> deleteImageList = imageService.findImageList(requestDto.getImageIdList());
+        List<Image> deleteImageList = imageService.findPostImage(postService.findPost(postId));
         List<String> deleteImageUrlList = new ArrayList<>();
         for(Image image:deleteImageList){
             deleteImageUrlList.add(image.getImageUrl());

--- a/src/main/java/com/efub/bageasy/domain/post/domain/Post.java
+++ b/src/main/java/com/efub/bageasy/domain/post/domain/Post.java
@@ -71,6 +71,7 @@ public class Post extends BaseTimeEntity {
        this.title=requestDto.getPostTitle();
        this.content=requestDto.getPostContent();
        this.price=requestDto.getPrice();
+       this.school = requestDto.getSchool();
 
     }
 

--- a/src/main/java/com/efub/bageasy/domain/post/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/efub/bageasy/domain/post/dto/PostUpdateRequestDto.java
@@ -23,7 +23,8 @@ public class PostUpdateRequestDto {
     private  String postContent;
     private Long price;
 
-    private List<Long> imageIdList = new ArrayList<>(); // 삭제할 이미지의 id
+    private String school;
+
 
 
 


### PR DESCRIPTION
### 요약
- 게시글을 수정할 때 부분적으로 이미지를 수정/삭제하는 것이 아니라 게시글의 이미지 전체를 새로 받도록 변경
- 게시글을 수정할 때 학교 정보도 수정할 수 있도록 변경

### 변경 사항
- requestDto 에서 삭제할 이미지 id 를 받는 부분 삭제
- requestDto 에서 학교 이름 필드 추가


### To Reviewers
- 해당 부분 담당하신 프론트 분께서 부분적으로 기존의 이미지를 삭제하고 추가하는 것이 어려울 것 같다고 하셔서  양도글의 기존 이미지를 모두 삭제한 후 아예 새로운 이미지를 받는 것으로 수정하였습니다.