### PR TITLE
feat : 채팅방 중복 예외처리 방식 변경

### DIFF
--- a/src/main/java/com/efub/bageasy/domain/chat/repository/RoomQuerydslRepository.java
+++ b/src/main/java/com/efub/bageasy/domain/chat/repository/RoomQuerydslRepository.java
@@ -16,14 +16,14 @@ public class RoomQuerydslRepository {
     @PersistenceContext
     private EntityManager em;
 
-    public Boolean isExistingRoom(Long buyerId, Long sellerId, Long postId){
+    public Long countExistingRoom(Long buyerId, Long sellerId, Long postId){
         JPAQueryFactory jpaQueryFactory = new JPAQueryFactory(em);
 
-        Integer fetchOne = jpaQueryFactory.selectOne()
+        Long fetchOne = jpaQueryFactory.select(room.roomId)
                 .from(room)
                 .where(room.buyerId.eq(buyerId), room.sellerId.eq(sellerId), room.postId.eq(postId))
-                .fetchFirst();
+                .fetchOne();
 
-        return fetchOne != null;
+        return fetchOne;
     }
 }

--- a/src/main/java/com/efub/bageasy/domain/chat/service/ChatService.java
+++ b/src/main/java/com/efub/bageasy/domain/chat/service/ChatService.java
@@ -67,8 +67,9 @@ public class ChatService {
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_MEMBER_EXIST));
 
         //이미 존재하는 채팅방
-        if(roomQuerydslRepository.isExistingRoom(member.getMemberId(), post.getMemberId(), post.getPostId()).equals(true)){
-            throw new CustomException(ErrorCode.ROOM_ALREADY_EXIST);
+        Long roomCount = roomQuerydslRepository.countExistingRoom(member.getMemberId(), post.getMemberId(), post.getPostId());
+        if(roomCount!= null){
+            throw new CustomException(ErrorCode.ROOM_ALREADY_EXIST, roomCount.toString() );
         }
 
         //자기자신을 채팅방에 초대하는 경우

--- a/src/main/java/com/efub/bageasy/global/exception/CustomException.java
+++ b/src/main/java/com/efub/bageasy/global/exception/CustomException.java
@@ -6,7 +6,14 @@ import lombok.Getter;
 public class CustomException extends RuntimeException{
     private ErrorCode errorCode;
 
+    private String info;
+
     public CustomException(ErrorCode errorCode) {
         this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String info){
+        this.errorCode = errorCode;
+        this.info = info;
     }
 }

--- a/src/main/java/com/efub/bageasy/global/exception/ErrorCode.java
+++ b/src/main/java/com/efub/bageasy/global/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
     ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "부적절한 argument입니다."),
     ROOM_NOT_EXIST(HttpStatus.BAD_REQUEST, "존재하지 않는 채팅방입니다."),
     ROOM_MEMBER_DUPLICATE(HttpStatus.BAD_REQUEST, "본인을 채팅방에 초대할 수 없습니다."),
-    ROOM_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 존재하는 채팅방입니다.");
+    ROOM_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 존재하는 채팅방. roomId : ");
 
 
 

--- a/src/main/java/com/efub/bageasy/global/exception/ErrorResponse.java
+++ b/src/main/java/com/efub/bageasy/global/exception/ErrorResponse.java
@@ -21,6 +21,15 @@ public class ErrorResponse {
     }
 
     public static ResponseEntity<ErrorResponse> error(CustomException e) {
+        if(e.getInfo()!=null){
+            return ResponseEntity
+                    .status(e.getErrorCode().getStatus())
+                    .body(ErrorResponse.builder()
+                            .status(e.getErrorCode().getStatus())
+                            .code(e.getErrorCode().name())
+                            .message(e.getErrorCode().getMessage()+e.getInfo())
+                            .build());
+        }
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.builder()


### PR DESCRIPTION
### 요약

### 변경 사항
- 중복된 채팅방을 생성하려 할 경우 이미 존재하는 채팅방 roomId를 리턴하도록 예외 처리 방식을 변경함.
- 예외 처리 로직에도 info 필드로 추가 정보를 넣을 수 있도록 변경. 따로 지정하지 않을 경우(info가 null일 경우) 기존 예외 발생 형식과 동일.
### To Reviewers