### PR TITLE
feat : 채팅 읽음 확인 기능 추가

### DIFF
--- a/src/main/java/com/efub/bageasy/domain/chat/domain/Chat.java
+++ b/src/main/java/com/efub/bageasy/domain/chat/domain/Chat.java
@@ -3,11 +3,13 @@ package com.efub.bageasy.domain.chat.domain;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.Id;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 public class Chat {
@@ -19,4 +21,5 @@ public class Chat {
     private String contentType; // notice 또는 talk
     private String content;
     private LocalDateTime sentAt;
+    private Boolean isRead;
 }

--- a/src/main/java/com/efub/bageasy/domain/chat/dto/Message.java
+++ b/src/main/java/com/efub/bageasy/domain/chat/dto/Message.java
@@ -34,6 +34,7 @@ public class Message implements Serializable {
 
     private String callbackNickname;
 
+
     @NotNull
     private int type;
 
@@ -59,6 +60,7 @@ public class Message implements Serializable {
                 .contentType(contentType)
                 .content(content)
                 .sentAt(Instant.ofEpochMilli(sentAt).atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime())
+                .isRead(false)
                 .build();
     }
 

--- a/src/main/java/com/efub/bageasy/domain/chat/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/com/efub/bageasy/domain/chat/dto/response/ChatRoomResponseDto.java
@@ -52,11 +52,16 @@ public class ChatRoomResponseDto {
     public static class LatestMessage{
         private long sentAt;
         private String content;
+        private Boolean isRead;
+
+        private Boolean isMine;
 
         @Builder
-        public LatestMessage(String content, LocalDateTime sentAt) {
+        public LatestMessage(String content, LocalDateTime sentAt, Boolean isRead, Boolean isMine) {
             this.content = content;
             this.sentAt = sentAt.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli();
+            this.isRead = isRead;
+            this.isMine = isMine;
         }
     }
 }

--- a/src/main/java/com/efub/bageasy/domain/chat/mongo/MongoChatRepository.java
+++ b/src/main/java/com/efub/bageasy/domain/chat/mongo/MongoChatRepository.java
@@ -8,9 +8,12 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface MongoChatRepository extends MongoRepository<Chat, String> {
-    List<Chat> findByRoomId(Long roomId);
+    List<Chat> findByRoomIdOrderBySentAt(Long roomId);
 
     Page<Chat> findByRoomIdAndSentAt(Long roomId, Pageable pageable);
 
     Page<Chat> findByRoomIdOrderBySentAtDesc(Long roomId, Pageable pageable);
+
+
+
 }

--- a/src/main/java/com/efub/bageasy/global/config/interceptor/StompHandler.java
+++ b/src/main/java/com/efub/bageasy/global/config/interceptor/StompHandler.java
@@ -1,8 +1,11 @@
 package com.efub.bageasy.global.config.interceptor;
 
+import com.efub.bageasy.domain.chat.dto.response.ChatRoomRecordDto;
 import com.efub.bageasy.domain.chat.service.ChatRoomService;
 import com.efub.bageasy.domain.chat.service.ChatService;
+import com.efub.bageasy.domain.member.repository.MemberRepository;
 import com.efub.bageasy.domain.member.service.JwtTokenProvider;
+import com.efub.bageasy.domain.member.service.MemberService;
 import com.efub.bageasy.global.exception.CustomException;
 import com.efub.bageasy.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ public class StompHandler implements ChannelInterceptor {
     private final JwtTokenProvider tokenProvider;
     private final ChatRoomService chatRoomService;
     private final ChatService chatService;
+    private final MemberRepository memberRepository;
 
     // 메시지가 실제로 체널로 전송되기 전에 호출
     @Override
@@ -47,6 +51,8 @@ public class StompHandler implements ChannelInterceptor {
             case SEND:
                 verifyAccessToken(getAccessToken(accessor));
                 break;
+            case DISCONNECT:
+                chatService.updateReadOnDisconnect(getChatRoomId(accessor), nickname);
         }
     }
 


### PR DESCRIPTION
- 실시간으로(websocket 통신시) 읽음 여부를 업데이트 하지는 않음
- 채팅방 목록 조회시 isRead와 IsMine 필드를 이용해 자신이 읽지 않은 메시지가 있는지 확인 가능
- 둘다 접속중일 경우에는 접속이 끊기는 순간에 읽음 상태를 업데이트
- 상대방이 접속해있지 않을 경우에는 상대방이 채팅방에 접속할 때 채팅 리스트 조회 api를 콜하는 순간 읽음 여부 업데이트

### 요약

### 변경 사항

### To Reviewers